### PR TITLE
Improve upload capture workflow

### DIFF
--- a/apps/web/src/app/upload/page.tsx
+++ b/apps/web/src/app/upload/page.tsx
@@ -5,7 +5,7 @@
 'use client'
 
 import type React from 'react'
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { supabaseBrowser } from '@/lib/supabase/browser'
 
 type Status = 'idle' | 'compressing' | 'uploading' | 'done' | 'error'
@@ -18,21 +18,59 @@ export default function UploadPage() {
   const videoRef = useRef<HTMLVideoElement | null>(null)
   const [usingCamera, setUsingCamera] = useState(false)
   const [stream, setStream] = useState<MediaStream | null>(null)
+  const [cameraSupported, setCameraSupported] = useState<boolean | null>(null)
+
+  const checkCameraSupport = useCallback(() => {
+    const supported =
+      typeof navigator !== 'undefined' &&
+      !!navigator.mediaDevices &&
+      typeof navigator.mediaDevices.getUserMedia === 'function'
+
+    setCameraSupported((prev) => (prev === supported ? prev : supported))
+    return supported
+  }, [])
 
   useEffect(() => {
     return () => {
-      if (stream) stream.getTracks().forEach((t) => t.stop())
+      stream?.getTracks().forEach((t) => t.stop())
+    }
+  }, [stream])
+
+  useEffect(() => {
+    return () => {
       if (previewUrl) URL.revokeObjectURL(previewUrl)
     }
-  }, [stream, previewUrl])
+  }, [previewUrl])
+
+  useEffect(() => {
+    checkCameraSupport()
+  }, [checkCameraSupport])
+
+  const updateFileWithPreview = useCallback((nextFile: File | null) => {
+    setFile(nextFile)
+    setPreviewUrl((prev) => {
+      if (prev) URL.revokeObjectURL(prev)
+      return nextFile ? URL.createObjectURL(nextFile) : null
+    })
+  }, [])
+
+  const stopCamera = useCallback(() => {
+    setStream((prev) => {
+      prev?.getTracks().forEach((t) => t.stop())
+      return null
+    })
+    if (videoRef.current) {
+      videoRef.current.srcObject = null
+      videoRef.current.pause()
+    }
+    setUsingCamera(false)
+  }, [])
 
   const onPickFile = (e: React.ChangeEvent<HTMLInputElement>) => {
     const f = e.target.files?.[0]
     if (!f) return
-    setFile(f)
-    const url = URL.createObjectURL(f)
-    setPreviewUrl(url)
-    setUsingCamera(false)
+    updateFileWithPreview(f)
+    if (usingCamera) stopCamera()
     setError(null)
     setStatus('idle')
   }
@@ -41,6 +79,12 @@ export default function UploadPage() {
   const startCamera = async () => {
     setError(null)
     try {
+      if (!checkCameraSupport()) {
+        throw new Error('Dieses Gerät unterstützt keine Kamera-Aufnahme im Browser.')
+      }
+
+      stopCamera()
+
       const s = await navigator.mediaDevices.getUserMedia({
         video: { facingMode: { ideal: 'environment' } },
         audio: false,
@@ -49,39 +93,67 @@ export default function UploadPage() {
       setUsingCamera(true)
       if (videoRef.current) {
         videoRef.current.srcObject = s
-        await videoRef.current.play()
+        videoRef.current.onloadedmetadata = () => {
+          videoRef.current
+            ?.play()
+            .catch((err) => console.error('Video play error:', err))
+        }
       }
-    } catch {
+    } catch (err) {
+      console.error(err)
+      stopCamera()
       setError('Kamera konnte nicht gestartet werden.')
     }
   }
 
   const captureFrame = async () => {
     if (!videoRef.current) return
-    const video = videoRef.current
-    const canvas = document.createElement('canvas')
-    canvas.width = video.videoWidth
-    canvas.height = video.videoHeight
-    const ctx = canvas.getContext('2d')!
-    ctx.drawImage(video, 0, 0)
-    const blob: Blob = await new Promise((resolve) =>
-      canvas.toBlob((b) => resolve(b as Blob), 'image/jpeg', 0.92),
-    )
-    const f = new File([blob], `camera-${Date.now()}.jpg`, { type: 'image/jpeg' })
-    setFile(f)
-    const url = URL.createObjectURL(f)
-    setPreviewUrl(url)
-    setError(null)
-    setStatus('idle')
+    try {
+      const video = videoRef.current
+      if (video.videoWidth === 0 || video.videoHeight === 0) {
+        console.warn('Video stream noch nicht bereit')
+        setError('Bitte warte einen Moment, bis das Kamerabild verfügbar ist.')
+        return
+      }
+      const canvas = document.createElement('canvas')
+      canvas.width = video.videoWidth
+      canvas.height = video.videoHeight
+      const ctx = canvas.getContext('2d')
+      if (!ctx) throw new Error('Canvas-Kontext nicht verfügbar.')
+      ctx.drawImage(video, 0, 0)
+      const blob: Blob = await new Promise((resolve, reject) =>
+        canvas.toBlob((b) => {
+          if (!b) {
+            reject(new Error('Konnte Kamerabild nicht verarbeiten.'))
+            return
+          }
+          resolve(b)
+        }, 'image/jpeg', 0.92),
+      )
+      const f = new File([blob], `camera-${Date.now()}.jpg`, { type: 'image/jpeg' })
+      updateFileWithPreview(f)
+      setError(null)
+      setStatus('idle')
+    } catch (err) {
+      console.error(err)
+      setError('Frame konnte nicht übernommen werden.')
+    }
   }
 
   // Kompression + EXIF-Strip (Canvas)
   const compressImage = async (input: File, maxDim = 2048, quality = 0.8): Promise<Blob> => {
     const img = await new Promise<HTMLImageElement>((resolve, reject) => {
       const image = new Image()
-      image.onload = () => resolve(image)
-      image.onerror = reject
-      image.src = URL.createObjectURL(input)
+      const objectUrl = URL.createObjectURL(input)
+      image.onload = () => {
+        URL.revokeObjectURL(objectUrl)
+        resolve(image)
+      }
+      image.onerror = (ev) => {
+        URL.revokeObjectURL(objectUrl)
+        reject(ev)
+      }
+      image.src = objectUrl
     })
 
     const { width, height } = img
@@ -92,12 +164,19 @@ export default function UploadPage() {
     const canvas = document.createElement('canvas')
     canvas.width = targetW
     canvas.height = targetH
-    const ctx = canvas.getContext('2d')!
+    const ctx = canvas.getContext('2d')
+    if (!ctx) throw new Error('Canvas-Kontext nicht verfügbar.')
     ctx.drawImage(img, 0, 0, targetW, targetH)
 
     // EXIF wird beim Canvas-Export entfernt
-    return await new Promise<Blob>((resolve) =>
-      canvas.toBlob((b) => resolve(b as Blob), 'image/jpeg', quality),
+    return await new Promise<Blob>((resolve, reject) =>
+      canvas.toBlob((b) => {
+        if (!b) {
+          reject(new Error('Bild konnte nicht komprimiert werden.'))
+          return
+        }
+        resolve(b)
+      }, 'image/jpeg', quality),
     )
   }
 
@@ -109,14 +188,15 @@ export default function UploadPage() {
       const compressed = await compressImage(file, 2048, 0.82)
 
       setStatus('uploading')
+      const supabase = supabaseBrowser()
       const {
         data: { user },
         error: userErr,
-      } = await supabaseBrowser().auth.getUser()
+      } = await supabase.auth.getUser()
       if (userErr || !user) throw new Error('Nicht eingeloggt.')
 
       const path = `${user.id}/${Date.now()}.jpg`
-      const { error: upErr } = await supabaseBrowser()
+      const { error: upErr } = await supabase
         .storage.from('raw_uploads')
         .upload(path, compressed, {
           contentType: 'image/jpeg',
@@ -126,6 +206,7 @@ export default function UploadPage() {
       if (upErr) throw upErr
 
       setStatus('done')
+      updateFileWithPreview(null)
     } catch (e: any) {
       setStatus('error')
       setError(e.message ?? 'Unbekannter Fehler')
@@ -151,7 +232,8 @@ export default function UploadPage() {
         <button
           className="px-4 py-2 rounded-xl bg-gray-200"
           onClick={startCamera}
-          disabled={usingCamera}
+          type="button"
+          disabled={usingCamera || cameraSupported === false}
         >
           Foto machen (Desktop Fallback)
         </button>
@@ -159,6 +241,7 @@ export default function UploadPage() {
         <button
           className="px-4 py-2 rounded-xl bg-black text-white disabled:opacity-50"
           onClick={upload}
+          type="button"
           disabled={!file || status === 'compressing' || status === 'uploading'}
         >
           {status === 'uploading'
@@ -169,25 +252,33 @@ export default function UploadPage() {
         </button>
       </div>
 
+      <div aria-live="polite" className="min-h-[1.5rem] text-sm text-gray-600">
+        {status === 'compressing' && 'Bild wird komprimiert…'}
+        {status === 'uploading' && 'Upload läuft…'}
+      </div>
+
       {usingCamera && (
         <div className="space-y-2">
           <video ref={videoRef} className="w-full rounded-xl bg-black" playsInline muted />
           <div className="flex gap-2">
-            <button className="px-4 py-2 rounded-xl bg-gray-200" onClick={captureFrame}>
+            <button
+              className="px-4 py-2 rounded-xl bg-gray-200"
+              onClick={captureFrame}
+              type="button"
+            >
               Frame übernehmen
             </button>
-            <button
-              className="px-4 py-2 rounded-xl"
-              onClick={() => {
-                stream?.getTracks().forEach((t) => t.stop())
-                setUsingCamera(false)
-                setStream(null)
-              }}
-            >
+            <button className="px-4 py-2 rounded-xl" onClick={stopCamera} type="button">
               Kamera stoppen
             </button>
           </div>
         </div>
+      )}
+
+      {cameraSupported === false && (
+        <p className="text-sm text-amber-700">
+          Dein Gerät oder Browser unterstützt keine Kamera-Aufnahme über den Desktop-Fallback.
+        </p>
       )}
 
       {previewUrl && (
@@ -200,11 +291,15 @@ export default function UploadPage() {
       )}
 
       {status === 'done' && (
-        <p className="text-green-700">
+        <p className="text-green-700" role="status" aria-live="polite">
           Upload erfolgreich! Du findest die Datei in deiner History.
         </p>
       )}
-      {status === 'error' && <p className="text-red-600">Fehler: {error}</p>}
+      {status === 'error' && (
+        <p className="text-red-600" role="alert">
+          Fehler: {error}
+        </p>
+      )}
     </main>
   )
 }


### PR DESCRIPTION
## Summary
- harden the upload page by improving camera capability detection, resource cleanup, and error reporting for both capture and compression
- centralize preview state handling, reset the UI after upload, and expose status messaging for better accessibility

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d7cceb04b8832c9d63cb52294ac9c9